### PR TITLE
--fix: memory leak and existing files

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -238,11 +238,12 @@ async def html2pdf():
 				
 			# build pdf
 			await page.pdf(options)
+			await page.close()
 
 			print(f"{chapter_no}.pdf created")
 
 	sem = asyncio.Semaphore(PUPPETEER_THREADS)
-	await asyncio.gather(*[render_page(chapter_no, sem) for chapter_no in contents])
+	await asyncio.gather(*[render_page(chapter_no, sem) for chapter_no in contents if not os.path.exists(f'{cache_dir}/{chapter_no}.pdf')])
 
 	await browser.close()
 


### PR DESCRIPTION
close pages after the pdf is saved in order to release the blocked memory for the garbage collector to clean up and reuse

ignore existing files instead of overwriting them